### PR TITLE
Use React Hot Loader for live-editing examples

### DIFF
--- a/examples/css-layout/app.js
+++ b/examples/css-layout/app.js
@@ -90,4 +90,4 @@ var App = React.createClass({
 
 });
 
-React.render(<App />, document.getElementById('main'));
+module.exports = App;

--- a/examples/css-layout/index.js
+++ b/examples/css-layout/index.js
@@ -1,0 +1,4 @@
+var React = require('react');
+var App = require('./app');
+
+React.render(<App />, document.getElementById('main'));

--- a/examples/listview/app.js
+++ b/examples/listview/app.js
@@ -59,4 +59,4 @@ var App = React.createClass({
 
 });
 
-React.render(<App />, document.getElementById('main'));
+module.exports = App;

--- a/examples/listview/index.js
+++ b/examples/listview/index.js
@@ -1,0 +1,4 @@
+var React = require('react');
+var App = require('./app');
+
+React.render(<App />, document.getElementById('main'));

--- a/examples/timeline/app.js
+++ b/examples/timeline/app.js
@@ -69,4 +69,4 @@ var App = React.createClass({
 
 });
 
-React.render(<App />, document.getElementById('main'));
+module.exports = App;

--- a/examples/timeline/index.js
+++ b/examples/timeline/index.js
@@ -1,0 +1,4 @@
+var React = require('react');
+var App = require('./app');
+
+React.render(<App />, document.getElementById('main'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,9 @@
 var gulp = require('gulp');
 var clean = require('gulp-clean');
-var connect = require('gulp-connect');
-var webpack = require('gulp-webpack');
+var webpack = require('webpack');
+var webpackPlugin = require('gulp-webpack');
 var webpackConfig = require('./webpack.config.js');
+var WebpackDevServer = require('webpack-dev-server');
 
 gulp.task('clean', function () {
   return gulp.src('build', {read: false})
@@ -11,23 +12,22 @@ gulp.task('clean', function () {
 
 gulp.task('build', function () {
   return gulp.src(webpackConfig.entry.timeline[0])
-    .pipe(webpack(webpackConfig))
+    .pipe(webpackPlugin(webpackConfig))
     .pipe(gulp.dest('build/'));
 });
 
 gulp.task('serve', function () {
-  connect.server({
-    livereload: true
+  new WebpackDevServer(webpack(webpackConfig), {
+    hot: true,
+    publicPath: webpackConfig.output.publicPath
+  }).listen(8080, 'localhost', function (err) {
+    if (err) {
+      return console.error(err);
+    }
+
+    console.log('Development server listening at http://localhost:8080/examples');
   });
 });
 
-gulp.task('reload-js', function () {
-  return gulp.src('./build/*.js')
-    .pipe(connect.reload());
-});
 
-gulp.task('watch', function () {
-  gulp.watch(['./build/*.js'], ['reload-js']);
-});
-
-gulp.task('default', ['clean', 'build', 'serve', 'watch']);
+gulp.task('default', ['clean', 'build', 'serve']);

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
     "url": "https://github.com/Flipboard/react-canvas/issues"
   },
   "devDependencies": {
-    "react": "^0.13.0-beta.1",
-    "webpack": "^1.5.3",
-    "transform-loader": "^0.2.1",
     "envify": "^3.2.0",
-    "jsx-loader": "^0.12.2",
     "gulp": "^3.8.10",
-    "gulp-connect": "^2.2.0",
+    "gulp-clean": "^0.3.1",
     "gulp-webpack": "^1.2.0",
-    "gulp-clean": "^0.3.1"
+    "jsx-loader": "^0.12.2",
+    "react": "^0.13.0-beta.1",
+    "react-hot-loader": "^1.1.4",
+    "transform-loader": "^0.2.1",
+    "webpack": "^1.5.3",
+    "webpack-dev-server": "^1.7.0"
   },
   "peerDependencies": {
     "react": "^0.13.0-beta.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,23 +1,34 @@
-module.exports = {
-  cache: true,
+var webpack = require('webpack');
 
-  watch: true,
+var hotServers = [
+  'webpack-dev-server/client?http://localhost:8080',
+  'webpack/hot/only-dev-server'
+];
+
+module.exports = {
+  devtool: 'eval',
 
   entry: {
-    'listview': ['./examples/listview/app.js'],
-    'timeline': ['./examples/timeline/app.js'],
-    'css-layout': ['./examples/css-layout/app.js']
+    'listview': ['./examples/listview/index'].concat(hotServers),
+    'timeline': ['./examples/timeline/index'].concat(hotServers),
+    'css-layout': ['./examples/css-layout/index'].concat(hotServers)
   },
 
   output: {
-    filename: '[name].js'
+    filename: '[name].js',
+    publicPath: '/build/'
   },
 
   module: {
     loaders: [
-      { test: /\.js$/, loader: 'jsx-loader!transform/cacheable?envify' },
+      { test: /\.js$/, loader: 'react-hot!jsx-loader!transform/cacheable?envify' },
     ]
   },
+
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  ],
 
   resolve: {
     root: __dirname,


### PR DESCRIPTION
Don't know if you're into that, but this gives you [React Hot Loader](http://gaearon.github.io/react-hot-loader/) powered live-editing for the examples. I noticed it doesn't update `<Text>` but a lot of other components (in examples and source) auto-update fine.

It's still `npm start`.