### PR TITLE
Support Unicode line breaking

### DIFF
--- a/lib/measureText.js
+++ b/lib/measureText.js
@@ -2,6 +2,7 @@
 
 var FontFace = require('./FontFace');
 var FontUtils = require('./FontUtils');
+var LineBreaker = require('linebreak');
 
 var canvas = document.createElement('canvas');
 var ctx = canvas.getContext('2d');
@@ -12,10 +13,6 @@ var _zeroMetrics = {
   height: 0,
   lines: []
 };
-
-function splitText (text) {
-  return text.split(' ');
-}
 
 function getCacheKey (text, width, fontFace, fontSize, lineHeight) {
   return text + width + fontFace.id + fontSize + lineHeight;
@@ -49,6 +46,9 @@ module.exports = function measureText (text, width, fontFace, fontSize, lineHeig
   var words;
   var tryLine;
   var currentLine;
+  var breaker;
+  var bk;
+  var lastBreak;
 
   ctx.font = fontFace.attributes.style + ' normal ' + fontFace.attributes.weight + ' ' + fontSize + 'pt ' + fontFace.family;
   textMetrics = ctx.measureText(text);
@@ -63,27 +63,31 @@ module.exports = function measureText (text, width, fontFace, fontSize, lineHeig
   } else {
     // Break into multiple lines.
     measuredSize.width = width;
-    words = splitText(text);
     currentLine = '';
-
-    // This needs to be optimized!
-    while (words.length) {
-      tryLine = currentLine + words[0] + ' ';
+    breaker = new LineBreaker(text);
+    
+    while (bk = breaker.nextBreak()) {
+      var word = text.slice(lastBreak ? lastBreak.position : 0, bk.position);
+      
+      tryLine = currentLine + word;
       textMetrics = ctx.measureText(tryLine);
-      if (textMetrics.width > width) {
+      if (textMetrics.width > width || (lastBreak && lastBreak.required)) {
         measuredSize.height += lineHeight;
         measuredSize.lines.push({width: lastMeasuredWidth, text: currentLine.trim()});
-        currentLine = words[0] + ' ';
+        currentLine = word;
         lastMeasuredWidth = ctx.measureText(currentLine.trim()).width;
       } else {
         currentLine = tryLine;
         lastMeasuredWidth = textMetrics.width;
       }
-      if (words.length === 1) {
-        textMetrics = ctx.measureText(currentLine.trim());
-        measuredSize.lines.push({width: textMetrics.width, text: currentLine.trim()});
-      }
-      words.shift();
+      
+      lastBreak = bk;
+    }
+    
+    currentLine = currentLine.trim();
+    if (currentLine.length > 0) {
+      textMetrics = ctx.measureText(currentLine);
+      measuredSize.lines.push({width: textMetrics, text: currentLine});
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/Flipboard/react-canvas/issues"
   },
   "devDependencies": {
+    "brfs": "^1.4.0",
     "del": "^1.1.1",
     "envify": "^3.2.0",
     "gulp": "^3.8.10",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^0.13.0-beta.1"
   },
   "dependencies": {
-    "linebreak": "^0.2.0",
+    "linebreak": "^0.3.0",
     "scroller": "git://github.com/mjohnston/scroller"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^0.13.0-beta.1"
   },
   "dependencies": {
+    "linebreak": "^0.2.0",
     "scroller": "git://github.com/mjohnston/scroller"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,9 @@ module.exports = {
   module: {
     loaders: [
       { test: /\.js$/, loader: 'jsx-loader!transform/cacheable?envify' },
+    ],
+    postLoaders: [
+      { loader: "transform?brfs" }
     ]
   },
 


### PR DESCRIPTION
This adds support for correctly breaking lines of unicode text in languages where there are no spaces between the words, such as CJK languages. It uses the [linebreak](https://github.com/devongovett/linebreak) module, which is an implementation of the [Unicode line breaking algorithm](http://www.unicode.org/reports/tr14/). The module is also used by my [PDFKit](https://github.com/devongovett/pdfkit) project.

Also adds support for force breaks (e.g. newlines) in the text as well, as a side benefit. :smile:

Tested by adding some Chinese text to the timeline demo:

![screen shot 2015-02-10 at 4 02 12 pm](https://cloud.githubusercontent.com/assets/19409/6139250/408ce306-b13e-11e4-9a46-19e0fcd2e485.png)
