### PR TITLE
Remove/replace deprecated stuff

### DIFF
--- a/examples/css-layout/index.html
+++ b/examples/css-layout/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>ReactCanvas: css-layout</title>
   <link rel="stylesheet" type="text/css" href="/examples/common/examples.css">
   <script src="/examples/common/touch-emulator.js"></script>

--- a/examples/listview/index.html
+++ b/examples/listview/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>ReactCanvas: ListView</title>
   <link rel="stylesheet" type="text/css" href="/examples/common/examples.css">
   <script src="/examples/common/touch-emulator.js"></script>

--- a/examples/timeline/index.html
+++ b/examples/timeline/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>ReactCanvas: Timeline</title>
   <link rel="stylesheet" type="text/css" href="/examples/common/examples.css">
   <script src="/examples/common/touch-emulator.js"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,11 @@
 var gulp = require('gulp');
-var clean = require('gulp-clean');
+var del = require('del');
 var connect = require('gulp-connect');
 var webpack = require('gulp-webpack');
 var webpackConfig = require('./webpack.config.js');
 
 gulp.task('clean', function () {
-  return gulp.src('build', {read: false})
-    .pipe(clean());
+  del(['build']);
 });
 
 gulp.task('build', function () {

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "url": "https://github.com/Flipboard/react-canvas/issues"
   },
   "devDependencies": {
-    "react": "^0.13.0-beta.1",
-    "webpack": "^1.5.3",
-    "transform-loader": "^0.2.1",
+    "del": "^1.1.1",
     "envify": "^3.2.0",
-    "jsx-loader": "^0.12.2",
     "gulp": "^3.8.10",
     "gulp-connect": "^2.2.0",
     "gulp-webpack": "^1.2.0",
-    "gulp-clean": "^0.3.1"
+    "jsx-loader": "^0.12.2",
+    "react": "^0.13.0-beta.1",
+    "transform-loader": "^0.2.1",
+    "webpack": "^1.5.3"
   },
   "peerDependencies": {
     "react": "^0.13.0-beta.1"


### PR DESCRIPTION
Fixes a few warnings that were tossed around:

* Removes the deprecated `minimal-ui` meta property.
* Replaces the deprecated `gulp-clean` with `del`.