### PR TITLE
Fix hit detection in listview by taking into account translation

### DIFF
--- a/examples/listview/app.js
+++ b/examples/listview/app.js
@@ -25,6 +25,10 @@ var App = React.createClass({
     );
   },
 
+  handleItemClick: function(title) {
+    console.log(title);
+  },
+
   renderItem: function (itemIndex, scrollTop) {
     var article = articles[itemIndex % articles.length];
       return (
@@ -33,6 +37,7 @@ var App = React.createClass({
         height={Item.getItemHeight()}
         imageUrl={article.imageUrl}
         title={article.title}
+        onClick={this.handleItemClick}
         itemIndex={itemIndex} />
     );
   },

--- a/examples/listview/components/Item.js
+++ b/examples/listview/components/Item.js
@@ -17,6 +17,7 @@ var Item = React.createClass({
     imageUrl: React.PropTypes.string.isRequired,
     title: React.PropTypes.string.isRequired,
     itemIndex: React.PropTypes.number.isRequired,
+    onClick: React.PropTypes.func
   },
 
   statics: {
@@ -25,9 +26,15 @@ var Item = React.createClass({
     }
   },
 
+  handleClick: function() {
+    if (this.props.onClick) {
+      this.props.onClick(this.props.title);
+    }
+  },
+
   render: function () {
     return (
-      <Group style={this.getStyle()}>
+      <Group style={this.getStyle()} onClick={this.handleClick}>
         <Image style={this.getImageStyle()} src={this.props.imageUrl} />
         <Text style={this.getTitleStyle()}>{this.props.title}</Text>
       </Group>

--- a/lib/LayerMixin.js
+++ b/lib/LayerMixin.js
@@ -44,10 +44,31 @@ var LayerMixin = {
     // TODO
   },
 
+  sumParentProp: function(propName, layer) {
+    var sum = 0;
+    var currentLayer = layer;
+    while (currentLayer) {
+      if (typeof currentLayer[propName] !== 'undefined') {
+        sum = sum + currentLayer[propName];
+      }
+      currentLayer = currentLayer.parentLayer;
+    }
+
+    return sum;
+  },
+
   applyLayerProps: function (prevProps, props) {
     var layer = this.node;
     var style = (props && props.style) ? props.style : {};
+    var left = style.left || 0;
+    var top = style.top || 0;
+    var frameLeft, frameTop;
     layer._originalStyle = style;
+
+    layer.translateX = style.translateX;
+    layer.translateY = style.translateY;
+    frameLeft = left + this.sumParentProp('translateX', layer);
+    frameTop = top + this.sumParentProp('translateY', layer);
 
     // Common layer properties
     layer.alpha = style.alpha;
@@ -55,10 +76,9 @@ var LayerMixin = {
     layer.borderColor = style.borderColor;
     layer.borderRadius = style.borderRadius;
     layer.clipRect = style.clipRect;
-    layer.frame = FrameUtils.make(style.left || 0, style.top || 0, style.width || 0, style.height || 0);
+    layer.frame = FrameUtils.make(left, top, style.width || 0, style.height || 0);
+    layer.hitFrame = FrameUtils.make(frameLeft, frameTop, style.width || 0, style.height || 0);
     layer.scale = style.scale;
-    layer.translateX = style.translateX;
-    layer.translateY = style.translateY;
     layer.zIndex = style.zIndex;
 
     // Generate backing store ID as needed.

--- a/lib/hitTest.js
+++ b/lib/hitTest.js
@@ -52,7 +52,7 @@ function getLayerAtPoint (root, type, point) {
   var layer = null;
   var hitHandle = getHitHandle(type);
   var sortedChildren;
-  var hitFrame = root.frame;
+  var hitFrame = root.hitFrame;
 
   // Early bail for non-visible layers
   if (typeof root.alpha === 'number' && root.alpha < 0.01) {


### PR DESCRIPTION
Related to #22 - onClick on an item in the listview would always fire on the last visible item, not the one that's actually being clicked. This fixed is it by creating a `hitFrame` property on the layer that factors in the layer and its parents' `translateX` and `translateY` values.