### PR TITLE
Add Jest for unit testing

### DIFF
--- a/lib/__tests__/clamp-test.js
+++ b/lib/__tests__/clamp-test.js
@@ -1,0 +1,17 @@
+jest.dontMock('../clamp.js');
+
+var clamp = require('../clamp');
+
+describe('clamp', function() {
+  it('returns the min if n is less than min', function() {
+    expect(clamp(-1, 0, 1)).toBe(0);
+  });
+
+  it('returns the max if n is greater than max', function() {
+    expect(clamp(2, 0, 1)).toBe(1);
+  });
+
+  it('returns n if n is between min and max', function() {
+    expect(clamp(0.5, 0, 1)).toBe(0.5);
+  });
+});

--- a/lib/clamp.js
+++ b/lib/clamp.js
@@ -10,4 +10,3 @@
 module.exports = function (number, min, max) {
   return Math.min(Math.max(number, min), max);
 };
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "./node_modules/.bin/gulp",
-    "test": "jest"
+    "test": "./node_modules/.bin/jest"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/Flipboard/react-canvas.git"
   },
   "scripts": {
-    "start": "./node_modules/.bin/gulp"
+    "start": "./node_modules/.bin/gulp",
+    "test": "jest"
   },
   "keywords": [
     "react",
@@ -26,6 +27,7 @@
     "gulp": "^3.8.10",
     "gulp-connect": "^2.2.0",
     "gulp-webpack": "^1.2.0",
+    "jest-cli": "^0.2.2",
     "jsx-loader": "^0.12.2",
     "react": "^0.13.0-beta.1",
     "transform-loader": "^0.2.1",


### PR DESCRIPTION
Related to #37 - added [Jest](http://facebook.github.io/jest/) as used by [react-art](https://github.com/reactjs/react-art), a similar library to react-canvas. Includes one simple test as an example, @mjohnston if this seems like it appropriate tool choice, I can add a few more tests to better assess the fit for this project.