### PR TITLE
Fix parent position when walking child nodes

### DIFF
--- a/lib/layoutNode.js
+++ b/lib/layoutNode.js
@@ -37,7 +37,7 @@ function walkNode (node, parentLeft, parentTop) {
   node.layer.frame.height = node.layout.height;
   if (node.children && node.children.length > 0) {
     node.children.forEach(function (child) {
-      walkNode(child, node.layout.left, node.layout.top);
+      walkNode(child, node.layer.frame.x, node.layer.frame.y);
     });
   }
 }


### PR DESCRIPTION
The child node needs to know its parent's absolute position in order to
determine its own absolute position. Previously, the parent's relative position
(in relation to its own parent) has been passed. This leads to wrong
positioning of nested nodes after several levels of recursion. I fixed this by
passing the current node's absolute position to the child nodes' layout
function.