### PR TITLE
Fix image layout when using css-layout

### DIFF
--- a/lib/DrawingUtils.js
+++ b/lib/DrawingUtils.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var ImageCache = require('./ImageCache');
-var FontUtils = require('./FontUtils');
-var FontFace = require('./FontFace');
-var FrameUtils = require('./FrameUtils');
+var assign      = require('react/lib/Object.assign');
+var Canvas      = require('./Canvas');
 var CanvasUtils = require('./CanvasUtils');
-var Canvas = require('./Canvas');
+var clamp       = require('./clamp');
+var FontFace    = require('./FontFace');
+var FontUtils   = require('./FontUtils');
+var FrameUtils  = require('./FrameUtils');
+var ImageCache  = require('./ImageCache');
 
 // Global backing store <canvas> cache
 var _backingStores = [];
@@ -372,6 +374,17 @@ function drawImageRenderLayer (ctx, layer) {
     return;
   }
 
+  var backgroundLayer = assign({}, layer);
+
+  // Background layer should be a simple Layer with inverted alpha of the image
+  backgroundLayer.imageUrl = null;
+  backgroundLayer.type = undefined;
+  backgroundLayer.alpha = clamp(1 - layer.alpha, 0, 1);
+
+  // Draw background color on the background layer, not on the image layer
+  layer.backgroundColor = null
+
+  drawRenderLayer(ctx, backgroundLayer)
   CanvasUtils.drawImage(ctx, image, layer.frame.x, layer.frame.y, layer.frame.width, layer.frame.height);
 }
 

--- a/lib/Image.js
+++ b/lib/Image.js
@@ -75,25 +75,14 @@ var Image = React.createClass({
   },
 
   render: function () {
-    var rawImage;
-    var imageStyle = assign({}, this.props.style);
     var style = assign({}, this.props.style);
-    var backgroundStyle = assign({}, this.props.style);
     var useBackingStore = this.state.loaded ? this.props.useBackingStore : false;
 
     // Hide the image until loaded.
-    imageStyle.alpha = this.state.imageAlpha;
-
-    // Hide opaque background if image loaded so that images with transparent
-    // do not render on top of solid color.
-    style.backgroundColor = imageStyle.backgroundColor = null;
-    backgroundStyle.alpha = clamp(1 - this.state.imageAlpha, 0, 1);
+    style.alpha = this.state.imageAlpha;
 
     return (
-      React.createElement(Group, {ref: 'main', style: style},
-        React.createElement(Layer, {ref: 'background', style: backgroundStyle}),
-        React.createElement(RawImage, {ref: 'image', src: this.props.src, style: imageStyle, useBackingStore: useBackingStore})
-      )
+      React.createElement(RawImage, {ref: 'image', src: this.props.src, style: style, useBackingStore: useBackingStore})
     );
   },
 


### PR DESCRIPTION
Flipboard/react-canvas#16 describes an issue with transparent PNGs not
rendering correctly. This was solved in 0146a0b by introducing a separate
background layer, which would render a plain surface with the specified
background color and then putting the actual image (without a background color)
before this surface. However, when using css-layout/flexbox to layout
components, this background surface was considered another valid component
sharing the available space with the actual image. This leads to an undesired
result, described in Flipboard/react-canvas#43.

I fixed this issue by reducing the React render tree down to the image again,
but moved the background layer creation to the canvas actual drawing stage.

Fixes Flipboard/react-canvas#43.