### PR TITLE
fixed listview positioning, by including top/left position in calculation

### DIFF
--- a/lib/ListView.js
+++ b/lib/ListView.js
@@ -64,6 +64,7 @@ var ListView = React.createClass({
       left: listViewLeft,
       width: this.props.style.width,
       height: itemHeight,
+      translateX: listViewLeft,
       translateY: (itemIndex * itemHeight) - this.state.scrollTop + listViewTop,
       zIndex: itemIndex
     };

--- a/lib/ListView.js
+++ b/lib/ListView.js
@@ -56,12 +56,15 @@ var ListView = React.createClass({
   renderItem: function (itemIndex) {
     var item = this.props.itemGetter(itemIndex, this.state.scrollTop);
     var itemHeight = this.props.itemHeightGetter();
+    var listViewTop = this.props.style.top || 0;
+    var listViewLeft = this.props.style.left || 0;
+
     var style = {
-      top: 0,
-      left: 0,
+      top: listViewTop,
+      left: listViewLeft,
       width: this.props.style.width,
       height: itemHeight,
-      translateY: (itemIndex * itemHeight) - this.state.scrollTop,
+      translateY: (itemIndex * itemHeight) - this.state.scrollTop + listViewTop,
       zIndex: itemIndex
     };
 


### PR DESCRIPTION
Currently, setting th top/left(in style props) of the ListView will not change the position. The fixes tends to make it works by including them in the items' top/left and the calculation of translateX/translateY.

Please correct me if I am wrong. Thank you