### PR TITLE
getDOMNode() has been deprecated. Use React.findDOMNode() instead.

### DIFF
--- a/lib/Surface.js
+++ b/lib/Surface.js
@@ -118,7 +118,7 @@ var Surface = React.createClass({
       this.isMounted(),
       'Tried to access drawing context on an unmounted Surface.'
     ) : invariant(this.isMounted()));
-    return this.refs.canvas.getDOMNode().getContext('2d');
+    return React.findDOMNode(this.refs.canvas).getContext('2d');
   },
 
   scale: function () {
@@ -168,14 +168,14 @@ var Surface = React.createClass({
   // ======
 
   hitTest: function (e) {
-    var hitTarget = hitTest(e, this.node, this.getDOMNode());
+    var hitTarget = hitTest(e, this.node, React.findDOMNode(this));
     if (hitTarget) {
       hitTarget[hitTest.getHitHandle(e.type)](e);
     }
   },
 
   handleTouchStart: function (e) {
-    var hitTarget = hitTest(e, this.node, this.getDOMNode());
+    var hitTarget = hitTest(e, this.node, React.findDOMNode(this));
     var touch;
     if (hitTarget) {
       // On touchstart: capture the current hit target for the given touch.


### PR DESCRIPTION
https://facebook.github.io/react/blog/2015/03/10/react-v0.13.html
https://facebook.github.io/react/docs/component-api.html#getdomnode