### PR TITLE
Allow canvas to be clickable on pages with scrolling

### DIFF
--- a/lib/hitTest.js
+++ b/lib/hitTest.js
@@ -21,6 +21,9 @@ function hitTest (e, rootLayer, rootNode) {
     touchX -= rootNodeBox.left;
     touchY -= rootNodeBox.top;
   }
+
+  touchY = touchY - window.pageYOffset;
+  touchX = touchX - window.pageXOffset;
   return getLayerAtPoint(
     rootLayer,
     e.type,


### PR DESCRIPTION
I'm building high performance UI with clickable canvas. We found out that react-canvas ignores scrolling offsets.