### PR TITLE
Fix #108: add crossOrigin prop on Image to allow getImageData/WebGL

### DIFF
--- a/lib/ImageCache.js
+++ b/lib/ImageCache.js
@@ -10,6 +10,7 @@ function Img (src) {
   this._img = new Image();
   this._img.onload = this.emit.bind(this, 'load');
   this._img.onerror = this.emit.bind(this, 'error');
+  this._img.crossOrigin = true;
   this._img.src = src;
 
   // The default impl of events emitter will throw on any 'error' event unless


### PR DESCRIPTION
This fixes issue #108,

It enables `crossOrigin` on all `Image` (see [CORS enabled image](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image)).


Without crossOrigin=true, if you try this code on any `react-canvas` app that uses images:

```js
var c = document.createElement("canvas");
ctx = c.getContext("2d");
page=document.querySelector("canvas");
c.width=page.width;
c.height=page.height;
ctx.drawImage(page, 0, 0);
ctx.getImageData(0, 0, page.width, page.height); // Screenshot the app :)
```

there will be following exception:

```
Uncaught DOMException: Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The canvas has been tainted by cross-origin data.
```

You need this feature when:

- you want to use getImageData to screenshot/video capture the application canvas.
- you want to draw the Canvas into WebGL (e.g: to add a cool effect on it). (this second reason brought me here :) )