### PR TITLE
port to React 0.14

### DIFF
--- a/examples/css-layout/app.js
+++ b/examples/css-layout/app.js
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ReactCanvas = require('react-canvas');
 
 var Surface = ReactCanvas.Surface;
@@ -103,4 +104,4 @@ var App = React.createClass({
 
 });
 
-React.render(<App />, document.getElementById('main'));
+ReactDOM.render(<App />, document.getElementById('main'));

--- a/examples/listview/app.js
+++ b/examples/listview/app.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ReactCanvas = require('react-canvas');
 var Item = require('./components/Item');
 var articles = require('../common/data');
@@ -59,4 +60,4 @@ var App = React.createClass({
 
 });
 
-React.render(<App />, document.getElementById('main'));
+ReactDOM.render(<App />, document.getElementById('main'));

--- a/examples/timeline/app.js
+++ b/examples/timeline/app.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ReactCanvas = require('react-canvas');
 var Page = require('./components/Page');
 var articles = require('../common/data');
@@ -69,4 +70,4 @@ var App = React.createClass({
 
 });
 
-React.render(<App />, document.getElementById('main'));
+ReactDOM.render(<App />, document.getElementById('main'));

--- a/lib/ContainerMixin.js
+++ b/lib/ContainerMixin.js
@@ -5,8 +5,8 @@
 
 var React = require('react');
 var ReactMultiChild = require('react/lib/ReactMultiChild');
-var assign = require('react/lib/Object.assign');
-var emptyObject = require('react/lib/emptyObject');
+var assign = require('object-assign');
+var emptyObject = require('fbjs/lib/emptyObject');
 
 var ContainerMixin = assign({}, ReactMultiChild.Mixin, {
 

--- a/lib/Surface.js
+++ b/lib/Surface.js
@@ -2,7 +2,7 @@
 
 var React = require('react');
 var ReactUpdates = require('react/lib/ReactUpdates');
-var invariant = require('react/lib/invariant');
+var invariant = require('fbjs/lib/invariant');
 var ContainerMixin = require('./ContainerMixin');
 var RenderLayer = require('./RenderLayer');
 var FrameUtils = require('./FrameUtils');
@@ -120,7 +120,7 @@ var Surface = React.createClass({
       this.isMounted(),
       'Tried to access drawing context on an unmounted Surface.'
     ) : invariant(this.isMounted()));
-    return this.refs.canvas.getDOMNode().getContext('2d');
+    return this.refs.canvas.getContext('2d');
   },
 
   scale: function () {
@@ -170,14 +170,14 @@ var Surface = React.createClass({
   // ======
 
   hitTest: function (e) {
-    var hitTarget = hitTest(e, this.node, this.getDOMNode());
+    var hitTarget = hitTest(e, this.node, this.refs.canvas);
     if (hitTarget) {
       hitTarget[hitTest.getHitHandle(e.type)](e);
     }
   },
 
   handleTouchStart: function (e) {
-    var hitTarget = hitTest(e, this.node, this.getDOMNode());
+    var hitTarget = hitTest(e, this.node, this.refs.canvas);
     var touch;
     if (hitTarget) {
       // On touchstart: capture the current hit target for the given touch.

--- a/package.json
+++ b/package.json
@@ -30,15 +30,18 @@
     "gulp-webpack": "^1.2.0",
     "jest-cli": "^0.2.2",
     "jsx-loader": "^0.12.2",
-    "react": "^0.13.0-beta.1",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "transform-loader": "^0.2.1",
     "webpack": "^1.5.3"
   },
   "peerDependencies": {
-    "react": "^0.13.0"
+    "react": "^0.14.0"
   },
   "dependencies": {
+    "fbjs": "^0.4.0",
     "linebreak": "^0.3.0",
+    "object-assign": "^4.0.1",
     "scroller": "git://github.com/mjohnston/scroller"
   }
 }


### PR DESCRIPTION
Please note that this **breaks backward compatibility** with older version of React because of the important changes done in react-0.14.
So don't increment a patch in the new release but increment a minor or a major (I guess a minor right?).
I think it's sane to increment at least a minor anyway, because trying to be backward compatible on this is IMO dangerous.

**Justification of changes:**
- react/lib have moved to fbjs/lib ( like done here https://github.com/reactjs/react-art/pull/59/files )
- fbjs itself doesn't exposes Object.assign but relies on https://github.com/facebook/fbjs/blob/master/package.json#L29
- in React 0.14, `getDOMNode()` is deprecated.
- as React 0.14 is split into `react` and `react-dom`, ReactDOM is used properly in examples

see also https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html

> Also, react-dom don't need to be added in peerDependencies, which means another target could be possible (imagine, you could render server side with a server-side canvas implementation)