### PR TITLE
Fix bugs in multiline Text

### DIFF
--- a/lib/measureText.js
+++ b/lib/measureText.js
@@ -43,7 +43,6 @@ module.exports = function measureText (text, width, fontFace, fontSize, lineHeig
   var measuredSize = {};
   var textMetrics;
   var lastMeasuredWidth;
-  var words;
   var tryLine;
   var currentLine;
   var breaker;
@@ -53,43 +52,39 @@ module.exports = function measureText (text, width, fontFace, fontSize, lineHeig
   ctx.font = fontFace.attributes.style + ' ' + fontFace.attributes.weight + ' ' + fontSize + 'px ' + fontFace.family;
   textMetrics = ctx.measureText(text);
 
-  measuredSize.width = textMetrics.width;
   measuredSize.height = lineHeight;
   measuredSize.lines = [];
 
-  if (measuredSize.width <= width) {
-    // The entire text string fits.
-    measuredSize.lines.push({width: measuredSize.width, text: text});
-  } else {
-    // Break into multiple lines.
-    measuredSize.width = width;
-    currentLine = '';
-    breaker = new LineBreaker(text);
-    
-    while (bk = breaker.nextBreak()) {
-      var word = text.slice(lastBreak ? lastBreak.position : 0, bk.position);
-      
-      tryLine = currentLine + word;
-      textMetrics = ctx.measureText(tryLine);
-      if (textMetrics.width > width || (lastBreak && lastBreak.required)) {
-        measuredSize.height += lineHeight;
-        measuredSize.lines.push({width: lastMeasuredWidth, text: currentLine.trim()});
-        currentLine = word;
-        lastMeasuredWidth = ctx.measureText(currentLine.trim()).width;
-      } else {
-        currentLine = tryLine;
-        lastMeasuredWidth = textMetrics.width;
-      }
-      
-      lastBreak = bk;
+  currentLine = '';
+  breaker = new LineBreaker(text);
+
+  while (bk = breaker.nextBreak()) {
+    var word = text.slice(lastBreak ? lastBreak.position : 0, bk.position);
+
+    tryLine = currentLine + word;
+    textMetrics = ctx.measureText(tryLine);
+    if (textMetrics.width > width || (lastBreak && lastBreak.required)) {
+      measuredSize.height += lineHeight;
+      measuredSize.lines.push({width: lastMeasuredWidth, text: currentLine.trim()});
+      currentLine = word;
+      lastMeasuredWidth = ctx.measureText(currentLine.trim()).width;
+    } else {
+      currentLine = tryLine;
+      lastMeasuredWidth = textMetrics.width;
     }
-    
-    currentLine = currentLine.trim();
-    if (currentLine.length > 0) {
-      textMetrics = ctx.measureText(currentLine);
-      measuredSize.lines.push({width: textMetrics, text: currentLine});
-    }
+    lastBreak = bk;
   }
+
+  currentLine = currentLine.trim();
+  if (currentLine.length > 0) {
+    textMetrics = ctx.measureText(currentLine);
+    measuredSize.lines.push({ width: textMetrics.width, text: currentLine });
+  }
+
+  // the measuredSize width is the widest line
+  measuredSize.width = measuredSize.lines.reduce(function (largest, line) {
+    return Math.max(largest, line.width);
+  }, 0);
 
   _cache[cacheKey] = measuredSize;
 


### PR DESCRIPTION
This PR fixes 3 critical bugs on Text when using the multiline feature (when you have a constraining width and height).
- **bug 1**: a small Text that fit in one line but contains '\n' is not handled as a multiline.
- **bug 2**: the measuredSize.width was inconsistent between singleline and multiline implementation. It's now uniformed with a max on the lines[i] width.
- **bug 3**: the last item of measuredSize.lines[i].width is not a number but a {width} . it makes a multiline text NOT rendering the last line.
