### PR TITLE
Ability to add an id or className to the top level Surface component.

### DIFF
--- a/lib/Surface.js
+++ b/lib/Surface.js
@@ -98,6 +98,8 @@ var Surface = React.createClass({
 
     return (
       React.createElement('canvas', {
+        className: this.props.className,
+        id: this.props.id,
         ref: 'canvas',
         width: width,
         height: height,


### PR DESCRIPTION
This commit allows one to add a className, and/or id, to the <Surface> tag similar to how one would do so in React. 

`<Surface className='allow-handle-click' id='canvasGrid'>
  </Surface>`